### PR TITLE
feat[flow-canvas]: Implement body tab UI with sub tab memory and MVC structure

### DIFF
--- a/src/pages/flow-canvas/components/api-list/ApiList.tsx
+++ b/src/pages/flow-canvas/components/api-list/ApiList.tsx
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import styles from '@/pages/flow-canvas/styles/BodyEditor.module.scss';
+import styles from '@/pages/flow-canvas/styles/ApiList.module.scss';
 import { mockEndpoints } from '../../__mocks__/mockNodeData.ts';
 
 /**

--- a/src/pages/flow-canvas/components/custom-node/BodyEditor.tsx
+++ b/src/pages/flow-canvas/components/custom-node/BodyEditor.tsx
@@ -1,12 +1,6 @@
-/**
- * @fileoverview BodyEditor.tsx
- *
- * BodyEditor is a popover UI component for editing the body of an API request.
- * It appears when the user toggles the body editor in a node and provides
- */
-
 import React, { MouseEvent } from 'react';
 import styles from '@/pages/flow-canvas/styles/BodyEditor.module.scss';
+import { useBodyEditorController } from '@/pages/flow-canvas/hooks/useBodyEditorController.ts';
 
 export interface BodyEditorProps {
   body: any;
@@ -15,16 +9,86 @@ export interface BodyEditorProps {
 }
 
 /**
- * Provides a container for displaying a body editor UI.
- * Prevents the click event from bubbling up to parent elements.
- * Useful for stopping node collapse when interacting inside the editor.
+ * BodyEditor component
+ * Uses a controller and hook to manage its tab state.
  */
-const BodyEditor: React.FC<BodyEditorProps> = ({ onClose }) => {
-  const handleClick = (e: MouseEvent) => {
+const BodyEditor: React.FC<BodyEditorProps> = ({ body, onSave, onClose }) => {
+  const { mainTab, subTab, selectMainTab, selectSubTab } = useBodyEditorController();
+
+  const stopCollapse = (e: MouseEvent) => {
     e.stopPropagation();
   };
 
-  return <div className={styles.editorPopover} onClick={handleClick}></div>;
+  return (
+    <div className={styles.editorPopover} onClick={stopCollapse}>
+      <div className={styles.mainTabs}>
+        <button
+          className={`${styles.tab} ${mainTab === 'request' ? styles.activeMainTab : ''}`}
+          onClick={() => selectMainTab('request')}
+        >
+          Request
+        </button>
+        <button
+          className={`${styles.tab} ${mainTab === 'response' ? styles.activeMainTab : ''}`}
+          onClick={() => selectMainTab('response')}
+        >
+          Response
+        </button>
+      </div>
+
+      <div className={styles.subTabs}>
+        <button
+          className={`${styles.tab} ${subTab === 'header' ? styles.activeSubTab : ''}`}
+          onClick={() => selectSubTab('header')}
+        >
+          Header
+        </button>
+
+        {mainTab === 'request' && (
+          <>
+            <button
+              className={`${styles.tab} ${subTab === 'body' ? styles.activeSubTab : ''}`}
+              onClick={() => selectSubTab('body')}
+            >
+              Body
+            </button>
+            <button
+              className={`${styles.tab} ${subTab === 'params' ? styles.activeSubTab : ''}`}
+              onClick={() => selectSubTab('params')}
+            >
+              Params
+            </button>
+          </>
+        )}
+
+        {mainTab === 'response' && (
+          <button
+            className={`${styles.tab} ${subTab === 'body' ? styles.activeSubTab : ''}`}
+            onClick={() => selectSubTab('body')}
+          >
+            Body
+          </button>
+        )}
+      </div>
+
+      <div className={styles.contentArea}>
+        {mainTab === 'request' && subTab === 'header' && <div>헤더</div>}
+        {mainTab === 'request' && subTab === 'body' && <div>바디</div>}
+        {mainTab === 'request' && subTab === 'params' && <div>파람</div>}
+        {mainTab === 'response' && subTab === 'header' && <div>헤더</div>}
+        {mainTab === 'response' && subTab === 'body' && <div>바디</div>}
+      </div>
+
+      <div className={styles.buttonRow}>
+        <button className={styles.saveButton} onClick={() => onSave(body)}>
+          save
+        </button>
+        <button className={styles.closeButton} onClick={onClose}>
+          close
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default BodyEditor;

--- a/src/pages/flow-canvas/components/custom-node/BodyEditor.tsx
+++ b/src/pages/flow-canvas/components/custom-node/BodyEditor.tsx
@@ -13,71 +13,52 @@ export interface BodyEditorProps {
  * Uses a controller and hook to manage its tab state.
  */
 const BodyEditor: React.FC<BodyEditorProps> = ({ body, onSave, onClose }) => {
-  const { mainTab, subTab, selectMainTab, selectSubTab } = useBodyEditorController();
+  const { mainTab, subTab, availableSubTabs, selectMainTab, selectSubTab } =
+    useBodyEditorController();
 
   const stopCollapse = (e: MouseEvent) => {
     e.stopPropagation();
   };
 
+  const tempContent = () => {
+    const key = `${mainTab}_${subTab}` as const;
+    const contentMap: Record<string, JSX.Element> = {
+      request_header: <div>헤더</div>,
+      request_body: <div>바디</div>,
+      request_params: <div>파람</div>,
+      response_header: <div>헤더</div>,
+      response_body: <div>바디</div>,
+    };
+    return contentMap[key];
+  };
+
   return (
     <div className={styles.editorPopover} onClick={stopCollapse}>
       <div className={styles.mainTabs}>
-        <button
-          className={`${styles.tab} ${mainTab === 'request' ? styles.activeMainTab : ''}`}
-          onClick={() => selectMainTab('request')}
-        >
-          Request
-        </button>
-        <button
-          className={`${styles.tab} ${mainTab === 'response' ? styles.activeMainTab : ''}`}
-          onClick={() => selectMainTab('response')}
-        >
-          Response
-        </button>
+        {(['request', 'response'] as const).map(tab => (
+          <button
+            key={tab}
+            className={`${styles.tab} ${mainTab === tab ? styles.activeMainTab : ''}`}
+            onClick={() => selectMainTab(tab)}
+          >
+            {tab[0].toUpperCase() + tab.slice(1)}
+          </button>
+        ))}
       </div>
 
       <div className={styles.subTabs}>
-        <button
-          className={`${styles.tab} ${subTab === 'header' ? styles.activeSubTab : ''}`}
-          onClick={() => selectSubTab('header')}
-        >
-          Header
-        </button>
-
-        {mainTab === 'request' && (
-          <>
-            <button
-              className={`${styles.tab} ${subTab === 'body' ? styles.activeSubTab : ''}`}
-              onClick={() => selectSubTab('body')}
-            >
-              Body
-            </button>
-            <button
-              className={`${styles.tab} ${subTab === 'params' ? styles.activeSubTab : ''}`}
-              onClick={() => selectSubTab('params')}
-            >
-              Params
-            </button>
-          </>
-        )}
-
-        {mainTab === 'response' && (
+        {availableSubTabs.map(tab => (
           <button
-            className={`${styles.tab} ${subTab === 'body' ? styles.activeSubTab : ''}`}
-            onClick={() => selectSubTab('body')}
+            key={tab}
+            className={`${styles.tab} ${subTab === tab ? styles.activeSubTab : ''}`}
+            onClick={() => selectSubTab(tab)}
           >
-            Body
+            {tab[0].toUpperCase() + tab.slice(1)}
           </button>
-        )}
+        ))}
       </div>
 
-      <div className={styles.contentArea}>
-        {mainTab === 'request' && subTab === 'header' && <div>헤더</div>}
-        {mainTab === 'request' && subTab === 'body' && <div>바디</div>}
-        {mainTab === 'request' && subTab === 'params' && <div>파람</div>}
-        {mainTab === 'response' && subTab === 'header' && <div>헤더</div>}
-        {mainTab === 'response' && subTab === 'body' && <div>바디</div>}
-      </div>
+      <div className={styles.contentArea}>{tempContent()}</div>
 
       <div className={styles.buttonRow}>
         <button className={styles.saveButton} onClick={() => onSave(body)}>

--- a/src/pages/flow-canvas/controllers/BodyEditorTabsController.ts
+++ b/src/pages/flow-canvas/controllers/BodyEditorTabsController.ts
@@ -3,28 +3,31 @@
  *
  * Manages the active main tab and tracks the last-selected sub tab for each main tab.
  */
-export class BodyEditorController {
-  private mainTab: 'request' | 'response' = 'request';
+type SubTab = 'header' | 'body' | 'params';
+type MainTab = 'request' | 'response';
 
-  private subTabMap: {
-    request: 'header' | 'body' | 'params';
-    response: 'header' | 'body';
-  } = {
+const allowedSubTabs: Record<MainTab, SubTab[]> = {
+  request: ['header', 'body', 'params'],
+  response: ['header', 'body'],
+};
+
+export class BodyEditorController {
+  private mainTab: MainTab = 'request';
+  private subTabMap: Record<MainTab, SubTab> = {
     request: 'header',
     response: 'header',
   };
-
   /**
    * @Returns the currently selected main tab.
    */
-  getMainTab(): 'request' | 'response' {
+  getMainTab(): MainTab {
     return this.mainTab;
   }
 
   /**
    * @Returns the sub tab associated with the active main tab.
    */
-  getSubTab(): 'header' | 'body' | 'params' {
+  getSubTab(): SubTab {
     return this.subTabMap[this.mainTab];
   }
 
@@ -32,7 +35,7 @@ export class BodyEditorController {
    * Switches the active main tab.
    * Does not reset sub tabs—instead preserves each tab’s last selection.
    */
-  selectMainTab(tab: 'request' | 'response') {
+  selectMainTab(tab: MainTab) {
     this.mainTab = tab;
   }
 
@@ -40,14 +43,14 @@ export class BodyEditorController {
    * Updates the sub tab for the active main tab.
    * @Throws if attempting to select 'params' under the 'response' tab.
    */
-  selectSubTab(tab: 'header' | 'body' | 'params') {
-    if (this.mainTab === 'request') {
-      this.subTabMap.request = tab;
-    } else {
-      if (tab === 'params') {
-        throw new Error('Cannot select "params" under the response tab.');
-      }
-      this.subTabMap.response = tab;
+  selectSubTab(tab: SubTab) {
+    if (!allowedSubTabs[this.mainTab].includes(tab)) {
+      throw new Error(`"${tab}" is not a valid sub-tab for "${this.mainTab}".`);
     }
+    this.subTabMap[this.mainTab] = tab;
+  }
+
+  getAvailableSubTabs(): SubTab[] {
+    return allowedSubTabs[this.mainTab];
   }
 }

--- a/src/pages/flow-canvas/controllers/BodyEditorTabsController.ts
+++ b/src/pages/flow-canvas/controllers/BodyEditorTabsController.ts
@@ -1,39 +1,53 @@
 /**
- * BodyEditorController class
+ * @fileoverview Controller for the BodyEditor popover.
  *
- * Manages the state of the BodyEditor popover, including main and sub tab selection.
+ * Manages the active main tab and tracks the last-selected sub tab for each main tab.
  */
 export class BodyEditorController {
   private mainTab: 'request' | 'response' = 'request';
-  private subTab: 'header' | 'body' | 'params' = 'body';
+
+  private subTabMap: {
+    request: 'header' | 'body' | 'params';
+    response: 'header' | 'body';
+  } = {
+    request: 'header',
+    response: 'header',
+  };
 
   /**
-   * Gets current main tab.
+   * @Returns the currently selected main tab.
    */
   getMainTab(): 'request' | 'response' {
     return this.mainTab;
   }
 
   /**
-   * Gets current sub tab.
+   * @Returns the sub tab associated with the active main tab.
    */
   getSubTab(): 'header' | 'body' | 'params' {
-    return this.subTab;
+    return this.subTabMap[this.mainTab];
   }
 
   /**
-   * Selects a main tab and resets sub tab to default for that context.
+   * Switches the active main tab.
+   * Does not reset sub tabs—instead preserves each tab’s last selection.
    */
   selectMainTab(tab: 'request' | 'response') {
     this.mainTab = tab;
-    // default sub-tab per main selection
-    this.subTab = tab === 'request' ? 'body' : 'header';
   }
 
   /**
-   * Selects a sub tab. UI should ensure only valid combos are passed.
+   * Updates the sub tab for the active main tab.
+   * @Throws if attempting to select 'params' under the 'response' tab.
    */
   selectSubTab(tab: 'header' | 'body' | 'params') {
-    this.subTab = tab;
+    if (this.mainTab === 'request') {
+      this.subTabMap.request = tab;
+    } else {
+      if (tab === 'params') {
+        throw new Error('Cannot select "params" under the response tab.');
+      }
+      this.subTabMap.response = tab;
+    }
   }
 }

--- a/src/pages/flow-canvas/controllers/BodyEditorTabsController.ts
+++ b/src/pages/flow-canvas/controllers/BodyEditorTabsController.ts
@@ -1,0 +1,39 @@
+/**
+ * BodyEditorController class
+ *
+ * Manages the state of the BodyEditor popover, including main and sub tab selection.
+ */
+export class BodyEditorController {
+  private mainTab: 'request' | 'response' = 'request';
+  private subTab: 'header' | 'body' | 'params' = 'body';
+
+  /**
+   * Gets current main tab.
+   */
+  getMainTab(): 'request' | 'response' {
+    return this.mainTab;
+  }
+
+  /**
+   * Gets current sub tab.
+   */
+  getSubTab(): 'header' | 'body' | 'params' {
+    return this.subTab;
+  }
+
+  /**
+   * Selects a main tab and resets sub tab to default for that context.
+   */
+  selectMainTab(tab: 'request' | 'response') {
+    this.mainTab = tab;
+    // default sub-tab per main selection
+    this.subTab = tab === 'request' ? 'body' : 'header';
+  }
+
+  /**
+   * Selects a sub tab. UI should ensure only valid combos are passed.
+   */
+  selectSubTab(tab: 'header' | 'body' | 'params') {
+    this.subTab = tab;
+  }
+}

--- a/src/pages/flow-canvas/hooks/useBodyEditorController.ts
+++ b/src/pages/flow-canvas/hooks/useBodyEditorController.ts
@@ -7,12 +7,14 @@ export const useBodyEditorController = () => {
   const [controller] = useState(() => new BodyEditorController());
   const [mainTab, setMainTab] = useState(controller.getMainTab());
   const [subTab, setSubTab] = useState(controller.getSubTab());
+  const [availableSubTabs, setAvailableSubTabs] = useState(controller.getAvailableSubTabs());
 
   const selectMainTab = useCallback(
     (tab: 'request' | 'response') => {
       controller.selectMainTab(tab);
       setMainTab(controller.getMainTab());
       setSubTab(controller.getSubTab());
+      setAvailableSubTabs(controller.getAvailableSubTabs());
     },
     [controller],
   );
@@ -28,6 +30,7 @@ export const useBodyEditorController = () => {
   return {
     mainTab,
     subTab,
+    availableSubTabs,
     selectMainTab,
     selectSubTab,
   };

--- a/src/pages/flow-canvas/hooks/useBodyEditorController.ts
+++ b/src/pages/flow-canvas/hooks/useBodyEditorController.ts
@@ -1,0 +1,34 @@
+import { useState, useCallback } from 'react';
+import { BodyEditorController } from '@/pages/flow-canvas/controllers/BodyEditorTabsController.ts';
+/**
+ * Hook to integrate BodyEditorController with React state.
+ */
+export const useBodyEditorController = () => {
+  const [controller] = useState(() => new BodyEditorController());
+  const [mainTab, setMainTab] = useState(controller.getMainTab());
+  const [subTab, setSubTab] = useState(controller.getSubTab());
+
+  const selectMainTab = useCallback(
+    (tab: 'request' | 'response') => {
+      controller.selectMainTab(tab);
+      setMainTab(controller.getMainTab());
+      setSubTab(controller.getSubTab());
+    },
+    [controller],
+  );
+
+  const selectSubTab = useCallback(
+    (tab: 'header' | 'body' | 'params') => {
+      controller.selectSubTab(tab);
+      setSubTab(controller.getSubTab());
+    },
+    [controller],
+  );
+
+  return {
+    mainTab,
+    subTab,
+    selectMainTab,
+    selectSubTab,
+  };
+};

--- a/src/pages/flow-canvas/styles/BodyEditor.module.scss
+++ b/src/pages/flow-canvas/styles/BodyEditor.module.scss
@@ -70,7 +70,7 @@
 .saveButton {
   background-color: $white;
   color: $primary-700;
-  border: 1.5px solid $primary-700 !important;
+  border: 1.5px solid $primary-700;
   cursor: pointer;
 
   &:hover {

--- a/src/pages/flow-canvas/styles/BodyEditor.module.scss
+++ b/src/pages/flow-canvas/styles/BodyEditor.module.scss
@@ -1,19 +1,55 @@
 /**
 * Additional popover + button section styles
 */
-
 .editorPopover {
   position: absolute;
   top: calc(100% + 8px);
   left: 0;
   width: 100%;
-  height: 200px;
+  height: auto;
   background: $white;
   border: 1px solid $outline-color;
   border-radius: $radius-lg;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(23, 10, 10, 0.15);
   z-index: 10;
   padding: 8px;
+}
+
+.mainTabs {
+  display: flex;
+  border-bottom: 1px solid $outline-color;
+  margin-bottom: 4px;
+}
+
+.subTabs {
+  display: flex;
+  margin-bottom: 4px;
+}
+
+.tab {
+  padding: 6px 12px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: $font-size-2xs;
+}
+.activeMainTab {
+  background: $gray-200;
+  font-weight: $font-weight-bold;
+  border-radius: $radius-sm;
+  margin-bottom: 3px;
+}
+.activeSubTab {
+  border-bottom: 1.5px solid $primary-700;
+  font-weight: $font-weight-bold;
+}
+
+.contentArea {
+  padding: 8px;
+  min-height: 100px;
+  background: $gray-50;
+  margin-bottom: 4px;
+  font-size: $font-size-2xs;
 }
 
 .buttonRow {
@@ -21,4 +57,35 @@
   justify-content: flex-end;
   gap: 4px;
   margin-top: 4px;
+}
+
+.saveButton,
+.closeButton {
+  padding: 2px 6px;
+  font-size: $font-size-2xs;
+  border-radius: $radius-sm;
+  font-weight: $font-weight-semibold;
+}
+
+.saveButton {
+  background-color: $white;
+  color: $primary-700;
+  border: 1.5px solid $primary-700 !important;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $primary-700;
+    color: $white;
+  }
+}
+.closeButton {
+  background-color: $gray-200;
+  color: $gray-800;
+  border: none;
+  border-radius: $radius-sm;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $gray-300;
+  }
 }

--- a/src/pages/flow-canvas/styles/CustomNode.module.scss
+++ b/src/pages/flow-canvas/styles/CustomNode.module.scss
@@ -70,6 +70,12 @@
   color: $fetch-font;
 }
 
+.stompMethod {
+  @extend .methodButton;
+  background-color: $fetch-bg;
+  color: $fetch-font;
+}
+
 .path {
   font-size: $font-size-xs;
   font-weight: $font-weight-medium;

--- a/src/pages/flow-canvas/styles/FlowCanvas.module.scss
+++ b/src/pages/flow-canvas/styles/FlowCanvas.module.scss
@@ -10,7 +10,7 @@
 .canvas {
   flex-grow: 1;
   height: 100vh;
-  background-color: $primary-50;
+  background-color: $gray-50;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -7,16 +7,17 @@ $white: #ffffff;
 $black: #000000;
 
 /** Primary Color Scale */
-$primary-50: #f3f7fb;
-$primary-100: #e5ebf4;
-$primary-200: #d3dfee;
-$primary-300: #b0c7e0;
-$primary-400: #8aa9d0;
-$primary-500: #6e8ec3;
-$primary-600: #5b77b5;
-$primary-700: #5066a5;
-$primary-800: #455588;
-$primary-900: #3b486d;
+$primary-50: #f3f3fc;
+$primary-100: #e7e7f7;
+$primary-200: #c9cbee;
+$primary-300: #999ee0;
+$primary-400: #626cce;
+$primary-500: #3d48ba;
+$primary-600: #2d339c;
+$primary-700: #25297f;
+$primary-800: #22266a;
+$primary-900: #212259;
+$primary-950: #030308;
 
 /** Gray Color Scale */
 $gray-50: #fafafa;


### PR DESCRIPTION
<!--  
Thank you for contributing to the API GHOST project.  
This document provides guidelines to ensure smooth collaboration and maintain high code quality.  
-->

<!--
PR Title Format Guideline

Use the following format for your PR title:

    type(scope): concise description

Examples:
    feat(api): add scenario execution support
    fix(parser): resolve YAML parsing error
    docs(readme): update CLI usage instructions

Available types:
    feat:     Add a new feature
    fix:      Fix a bug
    build:    Modify build system or external dependencies
    chore:    Modify configuration files unrelated to source or test files (e.g., .gitignore, .editorconfig)
    ci:       Update CI configuration files and scripts
    test:     Add or update tests
    docs:     Update documentation (e.g., README)
    refactor: Code changes that neither fix a bug nor add a feature
    style:    modify CSS styles
-->

### Related Issue

- #18 

### Description

- Updated the primary color.
- Implemented the body tab feature in nodes.
- Refactored BodyTab-related components following the MVC pattern.
- Enabled the sub tab state to be preserved when switching main tabs.

### Testing

Verified that the selected sub tab remains consistent even after switching the main tab.

![node](https://github.com/user-attachments/assets/9040ba01-9a3c-4ca1-946d-2913649e3897)

### Additional Notes

I attempted to apply the MVC pattern, but I acknowledge that I didn’t fully understand it yet.  
I feel frustrated about it, but I will continue to study and aim to use it confidently and correctly.

### Pre-Submission Checklist

- [x] Have you completed code style (convention) checks locally?
- [x] Have you passed the CI tests in your local environment?