### PR TITLE
feat(dashboard): add flow graph visualization for scenario test results

### DIFF
--- a/src/pages/dashboard/components/flow-graph-area/ApiRequestNode.tsx
+++ b/src/pages/dashboard/components/flow-graph-area/ApiRequestNode.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Handle, Position } from 'reactflow';
+import styles from '@/pages/dashboard/styles/ApiRequestNode.module.scss';
+import { ApiRequestData, NodeStatus } from '@/pages/dashboard/types/index.ts';
+import { getNodeStatusClass } from '@/pages/dashboard/utils/rechartUtils.ts';
+
+interface ApiRequestNodeProps {
+  data: ApiRequestData;
+  isConnectable: boolean;
+}
+
+const nodeStatusClassMap: Record<NodeStatus, string> = {
+  [NodeStatus.Success]: styles.success,
+  [NodeStatus.Error]: styles.error,
+  [NodeStatus.Unreachable]: styles.unreachable,
+};
+
+const ApiRequestNode: React.FC<ApiRequestNodeProps> = ({ data, isConnectable }) => {
+  const statusClass = getNodeStatusClass(data);
+  const statusClassName = nodeStatusClassMap[statusClass];
+
+  return (
+    <div className={`${styles.apiRequestNode} ${statusClassName}`}>
+      <Handle
+        type="target"
+        position={Position.Left}
+        isConnectable={isConnectable}
+        className={styles.handle}
+      />
+
+      <div className={styles.header}>
+        <div className={styles.method}>{data.method}</div>
+        <div className={styles.endpoint}>{data.endpoint}</div>
+      </div>
+
+      <div className={styles.content}>
+        <div className={styles.statusRow}>
+          <span className={styles.statusCode}>Status: {data.statusCode}</span>
+          <span className={styles.duration}>{data.durationMs}ms</span>
+        </div>
+      </div>
+
+      <Handle
+        type="source"
+        position={Position.Right}
+        isConnectable={isConnectable}
+        className={styles.handle}
+      />
+    </div>
+  );
+};
+
+export default ApiRequestNode;

--- a/src/pages/dashboard/components/flow-graph-area/FlowGraphArea.tsx
+++ b/src/pages/dashboard/components/flow-graph-area/FlowGraphArea.tsx
@@ -9,6 +9,8 @@
  */
 import { ResultItem } from '@/common/types/HistoryItem.ts';
 import styles from '@/pages/dashboard/styles/FlowGraphArea.module.scss';
+import { ReactFlowProvider } from 'reactflow';
+import ApiTestFlowGraph from '@/pages/dashboard/components/flow-graph-area/FlowGraphCanvas.tsx';
 
 interface FlowGraphAreaProps {
   results: ResultItem[];
@@ -18,7 +20,11 @@ const FlowGraphArea: React.FC<FlowGraphAreaProps> = ({ results }) => {
   return (
     <div className={styles.flowGraphArea}>
       <h4>Flow</h4>
-      <div className={styles.graphArea}></div>
+      <div className={styles.graphArea}>
+        <ReactFlowProvider>
+          <ApiTestFlowGraph apiResults={results} />
+        </ReactFlowProvider>
+      </div>
     </div>
   );
 };

--- a/src/pages/dashboard/components/flow-graph-area/FlowGraphCanvas.tsx
+++ b/src/pages/dashboard/components/flow-graph-area/FlowGraphCanvas.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect } from 'react';
+import { ReactFlow, useNodesState, useEdgesState, useReactFlow, NodeTypes } from 'reactflow';
+import 'reactflow/dist/style.css';
+import ApiRequestNode from '@/pages/dashboard/components/flow-graph-area/ApiRequestNode.tsx';
+import { ResultItem } from '@/common/types/index.ts';
+import { buildFlowElements } from '@/pages/dashboard/utils/rechartUtils.ts';
+import styles from '@/pages/dashboard/styles/FlowGraphArea.module.scss';
+
+const nodeTypes: NodeTypes = {
+  apiRequest: ApiRequestNode,
+};
+
+interface ApiTestFlowGraphProps {
+  apiResults: ResultItem[];
+}
+
+const ApiTestFlowGraph: React.FC<ApiTestFlowGraphProps> = ({ apiResults }) => {
+  const [nodes, setNodes, onNodesChange] = useNodesState([]);
+  const [edges, setEdges, onEdgesChange] = useEdgesState([]);
+  const { fitView } = useReactFlow();
+
+  useEffect(() => {
+    if (apiResults.length === 0) return;
+
+    const { nodes: newNodes, edges: newEdges } = buildFlowElements(apiResults);
+    setNodes(newNodes);
+    setEdges(newEdges);
+  }, [apiResults]);
+
+  useEffect(() => {
+    if (nodes.length > 0) {
+      const timeout = setTimeout(() => {
+        fitView({ padding: 0.1, includeHiddenNodes: true });
+      }, 100);
+      return () => clearTimeout(timeout);
+    }
+  }, [nodes, fitView]);
+
+  return (
+    <div className={styles.flowGraph}>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        fitView
+        maxZoom={1.2}
+        minZoom={0.2}
+        proOptions={{ hideAttribution: true }}
+        attributionPosition="bottom-right"
+      />
+    </div>
+  );
+};
+
+export default ApiTestFlowGraph;

--- a/src/pages/dashboard/constants/colors.ts
+++ b/src/pages/dashboard/constants/colors.ts
@@ -1,0 +1,18 @@
+export const COLORS = {
+  node: {
+    border: {
+      success: '#4CAF50',
+      error: '#F44336',
+      unreachable: '#9E9E9E',
+    },
+    background: {
+      success: '#E8F5E9',
+      error: '#FFEBEE',
+      unreachable: '#F5F5F5',
+    },
+  },
+  edge: {
+    stroke: '#888',
+    marker: '#888',
+  },
+};

--- a/src/pages/dashboard/styles/ApiRequestNode.module.scss
+++ b/src/pages/dashboard/styles/ApiRequestNode.module.scss
@@ -1,3 +1,13 @@
+$color-border-success: $primary-800;
+$color-border-error: $red-500;
+$color-border-unreachable: $gray-400;
+
+$color-method-success: $primary-800;
+$color-method-error: $red-500;
+$color-method-unreachable: $gray-400;
+
+$color-text-duration: $gray-400;
+
 .apiRequestNode {
   padding: 8px;
   border-radius: $radius-lg;
@@ -7,23 +17,23 @@
   width: 150px;
 
   &.success {
-    border-color: $primary-800;
+    border-color: $color-border-success;
     .method {
-      background-color: $primary-800;
+      background-color: $color-method-success;
     }
   }
 
   &.error {
-    border-color: $red-500;
+    border-color: $color-border-error;
     .method {
-      background-color: $red-500;
+      background-color: $color-method-error;
     }
   }
 
   &.unreachable {
-    border-color: $gray-400;
+    border-color: $color-border-unreachable;
     .method {
-      background-color: $gray-400;
+      background-color: $color-method-unreachable;
     }
   }
 }
@@ -62,9 +72,9 @@
 }
 
 .statusCode {
-  font-weight: 500;
+  font-weight: $font-weight-regular;
 }
 
 .duration {
-  color: $gray-400;
+  color: $color-text-duration;
 }

--- a/src/pages/dashboard/styles/FlowGraphArea.module.scss
+++ b/src/pages/dashboard/styles/FlowGraphArea.module.scss
@@ -10,5 +10,10 @@
 .graphArea {
   flex-grow: 1;
   background-color: $primary-50;
-  border-radius: 8px;
+  border-radius: $radius-lg;
+}
+
+.flowGraph {
+  height: 100%;
+  width: 100%;
 }

--- a/src/pages/dashboard/types/index.ts
+++ b/src/pages/dashboard/types/index.ts
@@ -1,0 +1,1 @@
+export * from './rechart.ts';

--- a/src/pages/dashboard/types/rechart.ts
+++ b/src/pages/dashboard/types/rechart.ts
@@ -1,0 +1,13 @@
+export enum NodeStatus {
+  Success = 'success',
+  Error = 'error',
+  Unreachable = 'unreachable',
+}
+
+export interface ApiRequestData {
+  endpoint: string;
+  method: string;
+  statusCode: number;
+  durationMs: number;
+  isRequestSuccess: boolean;
+}

--- a/src/pages/dashboard/utils/rechartUtils.ts
+++ b/src/pages/dashboard/utils/rechartUtils.ts
@@ -1,0 +1,52 @@
+import { Node, Edge, MarkerType } from 'reactflow';
+import { ResultItem } from '@/common/types/index.ts';
+import { ApiRequestData, NodeStatus } from '@/pages/dashboard/types/index.ts';
+import { COLORS } from '@/pages/dashboard/constants/colors.ts';
+
+const NODE_SPACING_X = 200;
+const NODE_SPACING_Y = 100;
+const NODE_BASE_Y = 250;
+
+const createNode = (result: ResultItem, index: number): Node<ApiRequestData> => ({
+  id: `node-${index}`,
+  type: 'apiRequest',
+  position: {
+    x: index * NODE_SPACING_X,
+    y: NODE_BASE_Y + (index % 3) * NODE_SPACING_Y,
+  },
+  data: result,
+});
+
+const createEdge = (sourceIndex: number, targetIndex: number): Edge => ({
+  id: `edge-${sourceIndex}-${targetIndex}`,
+  source: `node-${sourceIndex}`,
+  target: `node-${targetIndex}`,
+  type: 'smoothstep',
+  animated: false,
+  style: { stroke: COLORS.edge.stroke, strokeWidth: 2 },
+  markerEnd: {
+    type: MarkerType.ArrowClosed,
+    width: 15,
+    height: 15,
+    color: COLORS.edge.marker,
+  },
+});
+
+export const buildFlowElements = (
+  results: ResultItem[],
+): {
+  nodes: Node<ApiRequestData>[];
+  edges: Edge[];
+} => {
+  const nodes = results.map((result, index) => createNode(result, index));
+  const edges = results.slice(1).map((_, index) => createEdge(index, index + 1));
+
+  return { nodes, edges };
+};
+
+export const getNodeStatusClass = (data: ApiRequestData): NodeStatus =>
+  data.isRequestSuccess
+    ? NodeStatus.Success
+    : data.statusCode
+      ? NodeStatus.Error
+      : NodeStatus.Unreachable;


### PR DESCRIPTION
### Related Issue

- #23 

### Description

This PR introduces a visual representation of scenario test results using a flow graph based on **React Flow**. This enhances observability and debugging capabilities in the dashboard.

#### Key Changes:

* Implemented a new flow graph area using **React Flow** to visualize scenario test results
* Created a reusable `ApiRequestNode` component that encapsulates the UI for individual API request results
* Applied dynamic node styling to reflect request **success**, **failure**, or **unreachable** states
* Defined color constants for visual consistency across the graph (`colors.ts`)
* Added type definitions to support flow graph data modeling (`rechart.ts`)
* Organized SCSS styles and utility functions (`rechartUtils.ts`) for better maintainability

### Testing

* Verified correct rendering of flow graph with mock scenario results
* Tested dynamic node style switching by simulating different response statuses
* Ensured graph layout behaves as expected across different node counts

![image](https://github.com/user-attachments/assets/edfa0d22-6074-4eea-87a3-57db8b42011e)


### Additional Notes

* The integration is modularized to keep React Flow usage isolated from core dashboard logic
* This update may require updates in how scenario test data is structured or consumed
* Future improvements can include: zoom/pan behavior, edge labeling, or interactive node popups


### Pre-Submission Checklist

* [x] Have you completed code style (convention) checks locally?
* [x] Have you passed the CI tests in your local environment?
