### PR TITLE
feat(dashboard): connect scenario result API and add response interface

### DIFF
--- a/src/common/service/api.ts
+++ b/src/common/service/api.ts
@@ -10,7 +10,7 @@ export interface RequestOptions {
   authToken?: string;
 }
 
-const BASE_URL = '';
+const BASE_URL = 'http://localhost:8080';
 
 const buildQueryString = (params?: Record<string, string | number | boolean>): string =>
   params ? `?${new URLSearchParams(params as any).toString()}` : '';

--- a/src/common/service/apiClient.ts
+++ b/src/common/service/apiClient.ts
@@ -5,8 +5,6 @@ type Params = Record<string, string | number | boolean>;
 
 interface ClientOptions extends Omit<RequestOptions, 'method' | 'body' | 'params'> {}
 
-const BASE_URL = '';
-
 export const apiClient = {
   get: <T>(url: string, params?: Params, options: ClientOptions = {}): Promise<T> =>
     request<T>(url, {
@@ -61,7 +59,7 @@ export const apiClient = {
       Object.fromEntries(Object.entries(params).map(([key, value]) => [key, String(value)])),
     ).toString();
 
-    const fullUrl = `${BASE_URL}${url}?${queryString}`;
+    const fullUrl = `${url}?${queryString}`;
     const eventSource = new EventSource(fullUrl);
 
     eventSource.onmessage = onMessage;

--- a/src/common/types/index.ts
+++ b/src/common/types/index.ts
@@ -1,4 +1,4 @@
 export * from './tabItemTypes.ts';
-export * from './scenarioResultTypes.ts';
+// export * from '../../pages/dashboard/types/scenarioResultTypes.ts';
 export * from './apiTypes.ts';
 export * from './sidebarTypes.ts';

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -7,7 +7,7 @@ import { useTabsController } from '@/pages/dashboard/hooks/useTabsController.ts'
 import {
   ScenarioTestResultFileListItem,
   ScenarioTestDetailResponse,
-} from '@/common/types/index.ts';
+} from '@/pages/dashboard/types/index.ts';
 import {
   mockScenarioTestDetailResponse,
   mockScenarioTestResultFileList,

--- a/src/pages/dashboard/Dashboard.tsx
+++ b/src/pages/dashboard/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from '@/pages/dashboard/styles/Dashboard.module.scss';
 import MainContent from '@/pages/dashboard/components/main-content/MainContent.tsx';
 import HeaderTabs from '@/pages/dashboard/components/header-tabs/HeaderTabs.tsx';
@@ -9,9 +9,9 @@ import {
   ScenarioTestDetailResponse,
 } from '@/pages/dashboard/types/index.ts';
 import {
-  mockScenarioTestDetailResponse,
-  mockScenarioTestResultFileList,
-} from './__mocks__/mockHistoryList.ts';
+  getScenarioResultList,
+  getScenarioDetailResult,
+} from '@/pages/dashboard/service/resultService.ts';
 
 /**
  * Dashboard component renders the main dashboard layout with sidebar, tabs, and main content.
@@ -22,12 +22,23 @@ import {
  * @author haerim-kweon
  */
 const Dashboard: React.FC = () => {
-  const scenarioFileList: ScenarioTestResultFileListItem[] = mockScenarioTestResultFileList;
-  const selectedScenario: ScenarioTestDetailResponse | null = mockScenarioTestDetailResponse;
+  const [scenarioFileList, setScenarioFileList] = useState<ScenarioTestResultFileListItem[]>([]);
+  const [selectedScenario, setSelectedScenario] = useState<ScenarioTestDetailResponse | null>(null);
 
-  const onItemSelected = (item: any) => {
-    console.log(item);
+  const onItemSelected = async (item: ScenarioTestResultFileListItem) => {
+    try {
+      const response = await getScenarioDetailResult(item.fileName);
+      setSelectedScenario(response);
+    } catch (err) {
+      console.error('[Dashboard] getScenarioDetailResult Error', err);
+    }
   };
+
+  useEffect(() => {
+    getScenarioResultList()
+      .then(setScenarioFileList)
+      .catch(err => console.error('[Dashboard] getScenarioResultList Error', err));
+  }, []);
 
   const { tabs, selectedTab, selectTab, closeTab, handleSelectItem } = useTabsController<
     ScenarioTestResultFileListItem,
@@ -37,7 +48,7 @@ const Dashboard: React.FC = () => {
     itemList: scenarioFileList,
     idField: 'fileName',
     titleField: 'fileName',
-    onItemSelected: onItemSelected,
+    onItemSelected,
   });
 
   return (

--- a/src/pages/dashboard/__mocks__/mockHistoryList.ts
+++ b/src/pages/dashboard/__mocks__/mockHistoryList.ts
@@ -1,9 +1,8 @@
 import {
-  HttpMethod,
-  ProtocolType,
   ScenarioTestDetailResponse,
   ScenarioTestResultFileListItem,
-} from '@/common/types/index.ts';
+} from '@/pages/dashboard/types/index.ts';
+import { HttpMethod, ProtocolType } from '@/common/types/index.ts';
 
 const mockScenarioTestDetailResponse: ScenarioTestDetailResponse = {
   name: 'User Signup Scenario',
@@ -67,12 +66,12 @@ const mockScenarioTestDetailResponse: ScenarioTestDetailResponse = {
 const mockScenarioTestResultFileList: ScenarioTestResultFileListItem[] = [
   {
     fileName: 'user-scenario-result-01',
-    testSummary: 'success',
+    testSummary: true,
     timeStamp: '2025-04-23T07:57:59',
   },
   {
     fileName: 'user-scenario-result-02',
-    testSummary: 'fail',
+    testSummary: false,
     timeStamp: '2025-04-24T08:22:59',
   },
 ];

--- a/src/pages/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/pages/dashboard/__tests__/Dashboard.test.tsx
@@ -1,7 +1,15 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import Dashboard from '@/pages/dashboard/Dashboard';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
+import {
+  getScenarioResultList,
+  getScenarioDetailResult,
+} from '@/pages/dashboard/service/resultService.ts';
+import {
+  mockScenarioTestDetailResponse,
+  mockScenarioTestResultFileList,
+} from '@/pages/dashboard/__mocks__/mockHistoryList.ts';
 
 const getSidebarItem = (fileName: string) => screen.getByTestId(`sidebar-item-${fileName}`);
 const getHeaderTab = (fileName: string) => screen.getByTestId(`header-tab-${fileName}`);
@@ -10,44 +18,41 @@ const getCloseButton = (fileName: string) => screen.getByTestId(`close-button-${
 const FILE_NAME_1 = 'user-scenario-result-01';
 const FILE_NAME_2 = 'user-scenario-result-02';
 
-const mockOnItemSelected = jest.fn();
+jest.mock('@/pages/dashboard/service/resultService.ts');
 
-jest.mock('@/pages/dashboard/hooks/useTabsController.ts', () => {
-  const actual = jest.requireActual('@/pages/dashboard/hooks/useTabsController.ts');
+describe('Dashboard interaction tests (with mock service)', () => {
+  beforeEach(async () => {
+    (getScenarioResultList as jest.Mock).mockResolvedValue(mockScenarioTestResultFileList);
+    (getScenarioDetailResult as jest.Mock).mockResolvedValue(mockScenarioTestDetailResponse);
 
-  return {
-    __esModule: true,
-    useTabsController: (params: any) => {
-      const real = actual.useTabsController({
-        ...params,
-        onItemSelected: mockOnItemSelected,
-      });
-      return real;
-    },
-  };
-});
-
-describe('Dashboard interaction tests', () => {
-  beforeEach(() => {
-    mockOnItemSelected.mockClear();
     render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(getSidebarItem(FILE_NAME_1)).toBeInTheDocument();
+    });
   });
 
-  test('adds selected class when a scenario item is selected', async () => {
-    const item = getSidebarItem(FILE_NAME_1);
-    await userEvent.click(item);
-    expect(getSidebarItem(FILE_NAME_1)).toHaveAttribute('data-selected', 'true');
+  test('renders scenario list on initial load', () => {
+    expect(getSidebarItem(FILE_NAME_1)).toBeInTheDocument();
+    expect(getSidebarItem(FILE_NAME_2)).toBeInTheDocument();
   });
 
-  test('adds tab when sidebar item is clicked', async () => {
+  test('clicking sidebar item fetches detail and opens tab', async () => {
     await userEvent.click(getSidebarItem(FILE_NAME_1));
+    expect(getScenarioDetailResult).toHaveBeenCalledWith(FILE_NAME_1);
     expect(getHeaderTab(FILE_NAME_1)).toBeInTheDocument();
   });
 
-  test('selects existing tab if already opened', async () => {
-    await userEvent.click(getSidebarItem(FILE_NAME_1));
+  test('adds selected class when a scenario item is selected', async () => {
     await userEvent.click(getSidebarItem(FILE_NAME_1));
     expect(getSidebarItem(FILE_NAME_1)).toHaveAttribute('data-selected', 'true');
+  });
+
+  test('clicking same item again does not open duplicate tab', async () => {
+    await userEvent.click(getSidebarItem(FILE_NAME_1));
+    await userEvent.click(getSidebarItem(FILE_NAME_1));
+    const tabs = screen.getAllByTestId(new RegExp(`^header-tab-${FILE_NAME_1}`));
+    expect(tabs).toHaveLength(1);
   });
 
   test('selecting tab in HeaderTabs updates selected sidebar item', async () => {
@@ -59,28 +64,20 @@ describe('Dashboard interaction tests', () => {
 
   test('reselecting same tab does not change state', async () => {
     await userEvent.click(getSidebarItem(FILE_NAME_1));
-    const tab = getHeaderTab(FILE_NAME_1);
-    await userEvent.click(tab);
-    expect(getHeaderTab(FILE_NAME_1)).toHaveAttribute('data-selected', 'true');
+    await userEvent.click(getHeaderTab(FILE_NAME_1));
+    expect(getSidebarItem(FILE_NAME_1)).toHaveAttribute('data-selected', 'true');
   });
 
   test('closes tab from HeaderTabs', async () => {
     await userEvent.click(getSidebarItem(FILE_NAME_1));
     await userEvent.click(getCloseButton(FILE_NAME_1));
-    expect(screen.queryByTestId(`header-tab-${FILE_NAME_1}`)).toBeNull();
+    expect(screen.queryByTestId(`header-tab-${FILE_NAME_1}`)).not.toBeInTheDocument();
   });
 
-  test('closing selected tab selects first tab', async () => {
+  test('closing selected tab selects first tab if exists', async () => {
     await userEvent.click(getSidebarItem(FILE_NAME_1));
     await userEvent.click(getSidebarItem(FILE_NAME_2));
     await userEvent.click(getCloseButton(FILE_NAME_2));
-    expect(getHeaderTab(FILE_NAME_1)).toHaveAttribute('data-selected', 'true');
-  });
-
-  test('called onItemSelected by clicking sidebar item ', async () => {
-    await userEvent.click(getSidebarItem(FILE_NAME_1));
-    expect(mockOnItemSelected).toHaveBeenCalledWith(
-      expect.objectContaining({ fileName: FILE_NAME_1 }),
-    );
+    expect(getSidebarItem(FILE_NAME_1)).toHaveAttribute('data-selected', 'true');
   });
 });

--- a/src/pages/dashboard/components/flow-graph-area/FlowGraphArea.tsx
+++ b/src/pages/dashboard/components/flow-graph-area/FlowGraphArea.tsx
@@ -7,7 +7,7 @@
  * @author haerim-kweon
  */
 import React from 'react';
-import { ScenarioTestDetailResponseResult } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponseResult } from '@/pages/dashboard/types/index.ts';
 import styles from '@/pages/dashboard/styles/FlowGraphArea.module.scss';
 import { ReactFlowProvider } from 'reactflow';
 import ApiTestFlowGraph from '@/pages/dashboard/components/flow-graph-area/FlowGraphCanvas.tsx';

--- a/src/pages/dashboard/components/flow-graph-area/FlowGraphCanvas.tsx
+++ b/src/pages/dashboard/components/flow-graph-area/FlowGraphCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { ReactFlow, useNodesState, useEdgesState, useReactFlow, NodeTypes } from 'reactflow';
 import 'reactflow/dist/style.css';
 import ApiRequestNode from '@/pages/dashboard/components/flow-graph-area/ApiRequestNode.tsx';
-import { ScenarioTestDetailResponseResult } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponseResult } from '@/pages/dashboard/types/index.ts';
 import { buildFlowElements } from '@/pages/dashboard/utils/rechartUtils.ts';
 import styles from '@/pages/dashboard/styles/FlowGraphArea.module.scss';
 

--- a/src/pages/dashboard/components/latency-graph-area/LatencyGrahpArea.tsx
+++ b/src/pages/dashboard/components/latency-graph-area/LatencyGrahpArea.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import LatencyGraph from '@/pages/dashboard/components/latency-graph-area/LatencyGraph.tsx';
 import styles from '@/pages/dashboard/styles/LatencyGraphArea.module.scss';
-import { ScenarioTestDetailResponse } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponse } from '@/pages/dashboard/types/index.ts';
 
 interface LatencyGraphAreaProps {
   scenarioTestResult: ScenarioTestDetailResponse;

--- a/src/pages/dashboard/components/latency-graph-area/LatencyGraph.tsx
+++ b/src/pages/dashboard/components/latency-graph-area/LatencyGraph.tsx
@@ -10,7 +10,7 @@ import {
   ReferenceLine,
 } from 'recharts';
 import styles from '@/pages/dashboard/styles/LatencyGraph.module.scss';
-import { ScenarioTestDetailResponse } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponse } from '@/pages/dashboard/types/index.ts';
 
 interface LatencyGraphProps {
   scenarioTestResult: ScenarioTestDetailResponse;

--- a/src/pages/dashboard/components/main-content/MainContent.tsx
+++ b/src/pages/dashboard/components/main-content/MainContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ScenarioTestDetailResponse } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponse } from '@/pages/dashboard/types/index.ts';
 import styles from '@/pages/dashboard/styles/MainContent.module.scss';
 import FlowGraphArea from '@/pages/dashboard/components/flow-graph-area/FlowGraphArea.tsx';
 import LatencyGraphArea from '@/pages/dashboard/components/latency-graph-area/LatencyGrahpArea.tsx';

--- a/src/pages/dashboard/components/table-area/DetailRow.tsx
+++ b/src/pages/dashboard/components/table-area/DetailRow.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from '@/pages/dashboard/styles/TableArea.module.scss';
-import { ScenarioTestDetailResponseResult } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponseResult } from '@/pages/dashboard/types/index.ts';
 
 interface DetailRowProps {
   isOpen: boolean;

--- a/src/pages/dashboard/components/table-area/TableArea.tsx
+++ b/src/pages/dashboard/components/table-area/TableArea.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from '@/pages/dashboard/styles/TableArea.module.scss';
-import { ScenarioTestDetailResponseResult } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponseResult } from '@/pages/dashboard/types/index.ts';
 import TableRow from '@/pages/dashboard/components/table-area/TableRow.tsx';
 
 interface TableAreaProps {

--- a/src/pages/dashboard/components/table-area/TableRow.tsx
+++ b/src/pages/dashboard/components/table-area/TableRow.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styles from '@/pages/dashboard/styles/TableArea.module.scss';
-import { ScenarioTestDetailResponseResult } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponseResult } from '@/pages/dashboard/types/index.ts';
 import DetailRow from '@/pages/dashboard/components/table-area/DetailRow.tsx';
 import LightIndicator from '@/common/components/LightIndicator.tsx';
 

--- a/src/pages/dashboard/controllers/TabsController.ts
+++ b/src/pages/dashboard/controllers/TabsController.ts
@@ -12,51 +12,19 @@ import { TabItem } from '@/common/types/index.ts';
  * @author haerim-kweon
  */
 export class TabsController<T, K extends keyof T, L extends keyof T> {
-  private tabs: TabItem[] = [];
-  private selectedTabId?: string;
-  private itemList: T[];
-
-  /**
-   * Creates an instance of the TabsController.
-   *
-   * @param itemList - The list of items to create tabs for.
-   * @param idField - The field to use as the tab's unique identifier.
-   * @param titleField - The field to use as the tab's title.
-   */
   constructor(
     itemList: T[],
     private idField: K,
     private titleField: L,
-  ) {
-    this.itemList = itemList;
-  }
-
-  /**
-   * Retrieves the list of all current tabs.
-   *
-   * @returns The list of tabs.
-   */
-  getTabs() {
-    return this.tabs;
-  }
-
-  /**
-   * Retrieves the currently selected tab.
-   *
-   * @returns The selected tab, or undefined if no tab is selected.
-   */
-  getSelectedTab() {
-    return this.findTabById(this.selectedTabId);
-  }
+  ) {}
 
   /**
    * Selects a tab by its ID.
    *
    * @param id - The ID of the tab to select.
    */
-  selectTab(id: string) {
-    const tab = this.findTabById(id);
-    if (tab) this.selectedTabId = id;
+  selectTab(id: string, tabs: TabItem[]): TabItem | undefined {
+    return id ? tabs.find(tab => tab.id === id) : undefined;
   }
 
   /**
@@ -65,14 +33,15 @@ export class TabsController<T, K extends keyof T, L extends keyof T> {
    *
    * @param item - The item to create a new tab for.
    */
-  addTab(item: T) {
+  addTab(item: T, tabs: TabItem[]): TabItem[] {
     const id = String(item[this.idField]);
     const title = String(item[this.titleField]);
 
-    if (!this.tabs.some(t => t.id === id)) {
-      this.tabs.push({ id, title });
-      this.selectedTabId = id;
+    if (!tabs.some(t => t.id === id)) {
+      return [...tabs, { id, title }];
     }
+
+    return tabs;
   }
 
   /**
@@ -81,30 +50,7 @@ export class TabsController<T, K extends keyof T, L extends keyof T> {
    *
    * @param id - The ID of the tab to close.
    */
-  closeTab(id: string) {
-    this.tabs = this.tabs.filter(tab => tab.id !== id);
-    if (this.selectedTabId === id) {
-      this.selectedTabId = this.tabs.length > 0 ? this.tabs[0].id : undefined;
-    }
-  }
-
-  /**
-   * Retrieves the item associated with a specific tab.
-   *
-   * @param tab - The tab to retrieve the associated item for.
-   * @returns The item associated with the tab, or null if no item is found.
-   */
-  getItemForTab(tab?: { id: string; title: string }): T | null {
-    return tab ? (this.itemList.find(item => item[this.idField] === tab.id) ?? null) : null;
-  }
-
-  /**
-   * Finds a tab by its ID.
-   *
-   * @param id - The ID of the tab to find.
-   * @returns The tab with the matching ID, or undefined if not found.
-   */
-  findTabById(id?: string) {
-    return id ? this.tabs.find(tab => tab.id === id) : undefined;
+  closeTab(id: string, tabs: TabItem[]): TabItem[] {
+    return tabs.filter(tab => tab.id !== id);
   }
 }

--- a/src/pages/dashboard/service/resultService.ts
+++ b/src/pages/dashboard/service/resultService.ts
@@ -1,0 +1,19 @@
+import { apiClient } from '@/common/service/apiClient.ts';
+import {
+  ScenarioTestDetailResponse,
+  ScenarioTestResultFileListItem,
+  ScenarioTestResultFileListResponse,
+} from '@/pages/dashboard/types/index.ts';
+
+export const getScenarioResultList = async (): Promise<ScenarioTestResultFileListItem[]> => {
+  const response: ScenarioTestResultFileListResponse = await apiClient.get('/apighost/result-list');
+  return response.resultList;
+};
+
+export const getScenarioDetailResult = async (
+  fileName: string,
+): Promise<ScenarioTestDetailResponse> => {
+  return await apiClient.get<ScenarioTestDetailResponse>('/apighost/result-info', {
+    testResultName: fileName,
+  });
+};

--- a/src/pages/dashboard/service/resultService.ts
+++ b/src/pages/dashboard/service/resultService.ts
@@ -1,8 +1,8 @@
 import { apiClient } from '@/common/service/apiClient.ts';
 import {
   ScenarioTestDetailResponse,
-  ScenarioTestResultFileListItem,
   ScenarioTestResultFileListResponse,
+  ScenarioTestResultFileListItem,
 } from '@/pages/dashboard/types/index.ts';
 
 export const getScenarioResultList = async (): Promise<ScenarioTestResultFileListItem[]> => {

--- a/src/pages/dashboard/types/index.ts
+++ b/src/pages/dashboard/types/index.ts
@@ -1,1 +1,2 @@
 export * from './rechart.ts';
+export * from './scenarioResultTypes.ts';

--- a/src/pages/dashboard/types/scenarioResultTypes.ts
+++ b/src/pages/dashboard/types/scenarioResultTypes.ts
@@ -1,4 +1,4 @@
-import { HttpMethod, ProtocolType } from './apiTypes.ts';
+import { HttpMethod, ProtocolType } from '@/common/types/apiTypes.ts';
 
 export interface FormData {
   file?: Record<string, string>;

--- a/src/pages/dashboard/types/scenarioResultTypes.ts
+++ b/src/pages/dashboard/types/scenarioResultTypes.ts
@@ -34,9 +34,13 @@ export interface ScenarioTestDetailResponseResult {
   }>;
 }
 
+export interface ScenarioTestResultFileListResponse {
+  resultList: ScenarioTestResultFileListItem[];
+}
+
 export interface ScenarioTestResultFileListItem {
   fileName: string;
-  testSummary: string;
+  testSummary: boolean;
   timeStamp: string;
 }
 

--- a/src/pages/dashboard/utils/rechartUtils.ts
+++ b/src/pages/dashboard/utils/rechartUtils.ts
@@ -1,5 +1,5 @@
 import { Node, Edge, MarkerType } from 'reactflow';
-import { ScenarioTestDetailResponseResult } from '@/common/types/index.ts';
+import { ScenarioTestDetailResponseResult } from '@/pages/dashboard/types/index.ts';
 import { ApiRequestData, NodeStatus } from '@/pages/dashboard/types/index.ts';
 import { COLORS } from '@/pages/dashboard/constants/colors.ts';
 


### PR DESCRIPTION
### Related Issue

- #42 

### Description

This PR includes several updates related to the dashboard scenario result API integration and test coverage improvements.

Key changes:
- Added TypeScript interface for scenario result file list response.
- Implemented `getScenarioResultList` and `getScenarioDetailResult` API service functions.
- Connected the scenario result API to the Dashboard component with real data.
- Enhanced Dashboard functionality to fetch and render results based on user interaction.

### Testing

- Verified API response is fetched and rendered on the Dashboard component.
- Confirmed that clicking on sidebar items opens and closes tabs correctly.
- Test file includes:
  - Initial render scenario list check
  - Tab open on click
  - No duplicate tab on repeated click
  - Tab close functionality

Test results: ✅ All tests passed.
![image](https://github.com/user-attachments/assets/1df8e5ba-156c-44d6-8710-158b503f2ee5)

### Additional Notes


### Pre-Submission Checklist

- [x] Have you completed code style (convention) checks locally?
- [x] Have you passed the CI tests in your local environment?
