### PR TITLE
feat(flow-canvas): Preserve unsaved changes on route transitions

### DIFF
--- a/src/common/components/RoutingModal.tsx
+++ b/src/common/components/RoutingModal.tsx
@@ -1,15 +1,34 @@
 import React from 'react';
 import styles from './RoutingModal.module.scss';
 import { ROUTES } from '@/config/routes.ts';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useScenario } from '@/pages/flow-canvas/hooks/useScenario';
+import { useAppSelector } from '@/store/hooks';
 
 const RoutingModal: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { autoSave, autoLoad } = useScenario();
+  const selected = useAppSelector(state => state.scenario.selected);
+
+  const isOnCanvas = (path: string) => path.includes(ROUTES.FLOW_CANVAS.path);
+
+  const handleClick = async (path: string) => {
+    if (isOnCanvas(location.pathname) && selected) {
+      await autoSave(selected);
+    }
+
+    if (!isOnCanvas(location.pathname) && isOnCanvas(path) && selected) {
+      await autoLoad(selected.name + '.yaml');
+    }
+
+    navigate(path);
+  };
 
   return (
     <div className={styles.container}>
       {Object.values(ROUTES).map(({ path, label, icon }) => (
-        <button key={path} onClick={() => navigate(path)} className={styles.button}>
+        <button key={path} onClick={() => handleClick(path)} className={styles.button}>
           <img src={icon} alt={label} width={20} height={20} />
         </button>
       ))}

--- a/src/common/utils/jsonUtils.ts
+++ b/src/common/utils/jsonUtils.ts
@@ -71,3 +71,13 @@ const parseField = (field: Field): any => {
 
   return field.value;
 };
+
+export const parseBaseUrl = (url: string): string => {
+  const baseURl = url.split('/');
+  return baseURl[0] + '/' + '/' + baseURl[2];
+};
+
+export const parseEndpoint = (url: string): string => {
+  const Endpoint = url.split('/');
+  return '/' + Endpoint.slice(3).join('/');
+};

--- a/src/common/utils/scenarioToReactFlow.ts
+++ b/src/common/utils/scenarioToReactFlow.ts
@@ -1,5 +1,6 @@
 import { Node, Edge } from 'reactflow';
 import { ScenarioInfo } from '@/pages/flow-canvas/types';
+import { parseBaseUrl, parseEndpoint } from '@/common/utils/jsonUtils';
 
 export const scenarioToFlowElements = (
   scenario: ScenarioInfo | null,
@@ -17,9 +18,9 @@ export const scenarioToFlowElements = (
       data: {
         endpointId: stepId,
         header: step.request.header,
-        baseUrl: step.request.url,
+        baseUrl: parseBaseUrl(step.request.url),
         method: step.request.method,
-        path: step.request.url,
+        path: parseEndpoint(step.request.url),
         requestSchema: step.request.body,
         responseSchema: step.route.map(r => r.expected),
         showBody: false,

--- a/src/pages/flow-canvas/FlowCanvas.tsx
+++ b/src/pages/flow-canvas/FlowCanvas.tsx
@@ -133,13 +133,18 @@ const FlowCanvas: React.FC = () => {
   const [isConnected, setIsConnected] = useState(false);
 
   const handlePlay = (fileName: string | undefined) => {
-    if (!fileName) return;
+    console.log('hihihihi');
+    if (!fileName) {
+      console.log('heelo!!');
+      return;
+    }
     if (isConnected) {
       eventSourceRef.current?.close();
       eventSourceRef.current = null;
       setIsConnected(false);
     } else {
       const eventSource = scenarioTest(fileName);
+      console.log(fileName);
       eventSourceRef.current = eventSource;
       setIsConnected(true);
 

--- a/src/pages/flow-canvas/FlowCanvasMain.tsx
+++ b/src/pages/flow-canvas/FlowCanvasMain.tsx
@@ -9,14 +9,20 @@ import WelcomePage from '@/pages/flow-canvas/WelcomePage';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { selectScenario, setScenarioList } from '@/store/slices/scenarioSlice';
 import { getScenarioInfo, getScenarioList } from '@/pages/flow-canvas/service/scenarioService';
+import { useScenario } from '@/pages/flow-canvas/hooks/useScenario';
 
 const FlowCanvasMain: React.FC = () => {
   const dispatch = useAppDispatch();
   const scenarios = useAppSelector(state => state.scenario.list);
   const selected = useAppSelector(state => state.scenario.selected);
+  const { autoSave } = useScenario();
 
   const handleSelect = async (name: string) => {
+    if (selected) {
+      const ok = await autoSave(selected);
+    }
     const info = await getScenarioInfo(name);
+    console.log('newFile Name: ', name);
     dispatch(selectScenario(info));
   };
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,7 +10,7 @@ const router = createBrowserRouter([
     element: <AppLayout />,
     errorElement: <NotFound />,
     children: [
-      { path: '', element: <Navigate to={ROUTES.FLOW_CANVAS.path} /> },
+      { path: '', element: <Navigate to={ROUTES.FLOW_CANVAS.path} replace /> },
       { path: ROUTES.FLOW_CANVAS.path, element: <FlowCanvasMain /> },
       { path: ROUTES.DASHBOARD.path, element: <Dashboard /> },
     ],

--- a/src/store/thunks/exportScenario.ts
+++ b/src/store/thunks/exportScenario.ts
@@ -18,12 +18,12 @@ export const exportScenario = createAsyncThunk(
   async (meta: Payload, { getState, rejectWithValue }) => {
     const state = getState() as RootState;
     const { nodes, edges } = state.flow;
-    console.log('[exportScenario] nodes →', nodes);
-    console.log('[exportScenario] edges →', edges);
+    // console.log('[exportScenario] nodes →', nodes);
+    // console.log('[exportScenario] edges →', edges);
 
     const schemaState = state.schemaEditor;
     console.log(
-      '[exportScenario] state.flow.edges.mappingInfo →',
+      // '[exportScenario] state.flow.edges.mappingInfo →',
       edges.map(e => ({
         id: e.id,
         mappingInfo: (e.data as any)?.mappingInfo ?? null,
@@ -35,9 +35,12 @@ export const exportScenario = createAsyncThunk(
     nodes.forEach(node => {
       const id = node.id;
       const entry = schemaState[id];
-      const finalRequestSchema = entry?.requestSchema?.length
-        ? entry.requestSchema
-        : (node.data.requestSchema ?? []);
+
+      const rawSchema = entry?.requestSchema ?? node.data.requestSchema;
+      const finalRequestSchema: Field[] = Array.isArray(rawSchema) ? rawSchema : [];
+      // const finalRequestSchema = entry?.requestSchema?.length
+      //   ? entry.requestSchema
+      //   : (node.data.requestSchema ?? []);
       const jsonObj = finalRequestSchema.reduce(
         (acc: Record<string, any>, f: Field) => {
           if (f.value !== undefined) acc[f.name] = f.value;


### PR DESCRIPTION
### Related Issue

- #66

### Description

- Enabled **auto-saving** when navigating away from the current work.
- Implemented logic to **preserve existing work** when navigating between pages using the router.
- Ensured that the previous work **restores correctly** when returning to a previously visited page.

### Testing

- Manually navigated across pages to verify auto-save functionality.
- Confirmed that previously edited work is retained after returning to the same page.

### Additional Notes

- Work remains for handling navigation via **direct URL input**.  
  This will be discussed and scheduled separately.

### Pre-Submission Checklist

- [x] Code style (convention) checks completed locally  
- [x] Passed CI tests in local environment